### PR TITLE
Icon-fix when using AppIndicator3

### DIFF
--- a/caffeine/main.py
+++ b/caffeine/main.py
@@ -165,8 +165,8 @@ class GUI:
 
         if appindicator_avail:
             self.AppInd = \
-                AppIndicator3.Indicator.new("caffeine-cup-empty",
-                                            "caffeine",
+                AppIndicator3.Indicator.new("caffeine",
+                                            "caffeine-cup-empty",
                                             AppIndicator3.IndicatorCategory.
                                             APPLICATION_STATUS)
 


### PR DESCRIPTION
Tested it on stock Fedora 21 under Gnome Shell.