### PR TITLE
Added inhibitor for xautolock

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ System requirements
 -------------------
 
 * Either a screensaver that implements the org.freedesktop.ScreenSaver API
-  (this includes KDE, amongst others) API, gnome-screensaver, XSS and/or DPMS.
+  (this includes KDE, amongst others) API, gnome-screensaver, XSS and/or DPMS, xautolock.
 
 * Python 3
 

--- a/caffeine/core.py
+++ b/caffeine/core.py
@@ -28,7 +28,7 @@ from . import utils
 from .icons import empty_cup_icon, full_cup_icon
 from .inhibitors import DpmsInhibitor, GnomeInhibitor, \
     XdgPowerManagmentInhibitor, XdgScreenSaverInhibitor, XssInhibitor, \
-    XorgInhibitor
+    XorgInhibitor, XautolockInhibitor
 
 # from pympler import tracker
 # tr = tracker.SummaryTracker()
@@ -51,7 +51,8 @@ class Caffeine(GObject.GObject):
             XdgPowerManagmentInhibitor(),
             XssInhibitor(),
             DpmsInhibitor(),
-            XorgInhibitor()
+            XorgInhibitor(),
+            XautolockInhibitor()
         ]
 
         self.__process_manager = process_manager

--- a/caffeine/inhibitors.py
+++ b/caffeine/inhibitors.py
@@ -197,3 +197,23 @@ class XorgInhibitor(BaseInhibitor):
     def applicable(self):
         # TODO!
         return True
+
+
+class XautolockInhibitor(BaseInhibitor):
+
+    def __init__(self):
+        BaseInhibitor.__init__(self)
+
+    def inhibit(self):
+        self.running = True
+
+        os.system("xautolock -disable")
+
+    def uninhibit(self):
+        self.running = False
+
+        os.system("xautolock -enable")
+
+    @property
+    def applicable(self):
+        return os.system("pgrep xautolock") is 0


### PR DESCRIPTION
With this xautolock is also disabled if caffeine is active.

xautolock is often used to lock the screen in tiling window managers automatically.
e.g. lock screen with i3lock after 5 min:
```
xautolock -time 5 -locker 'i3lock -c 000000'
```

Thank you!