### PR TITLE
process names are saved in lowercase

### DIFF
--- a/caffeine/main.py
+++ b/caffeine/main.py
@@ -124,7 +124,7 @@ class ProcAdd:
         return response
 
     def get_process_name(self):
-        return self.entry.get_text().strip()
+        return self.entry.get_text().lower().strip()
 
     def on_add_button_clicked(self, button, data=None):
         self.dialog.hide()


### PR DESCRIPTION
When you ask the list of running processes, you lowercase the names of the processes.

However, when the user specifies a process, it's not lowercased. So I didn't understand why "Popcorn-Time" is ignored when I copied it from the output of "ps aux". I had to dive in the code to figure out what was going wrong.

So here is a simple patch. When the user provides a process name, it's lowercased immediately, so it doesn't matter how the user types it in.

BTW, thanks for the project, I find it very useful.