### PR TITLE
Wrap proxies in Interfaces; add inhibit suspend flag to GnomeInhibitor.

### DIFF
--- a/caffeine/inhibitors.py
+++ b/caffeine/inhibitors.py
@@ -64,10 +64,13 @@ class GnomeInhibitor(BaseInhibitor):
         if not self.__proxy:
             self.__proxy = self.bus.get_object('org.gnome.SessionManager',
                                                '/org/gnome/SessionManager')
+            self.__proxy = \
+                dbus.Interface(self.__proxy,
+                               dbus_interface='org.gnome.SessionManager')
 
         self.__cookie = self.__proxy.Inhibit("Caffeine", dbus.UInt32(0),
                                              INHIBITION_REASON,
-                                             dbus.UInt32(8))
+                                             dbus.UInt32(12))
         self.running = True
 
     def uninhibit(self):
@@ -91,6 +94,9 @@ class XdgScreenSaverInhibitor(BaseInhibitor):
     def inhibit(self):
         self.__proxy = \
             self.bus.get_object('org.freedesktop.ScreenSaver', '/ScreenSaver')
+        self.__proxy = \
+            dbus.Interface(self.__proxy,
+                           dbus_interface='org.freedesktop.ScreenSaver')
         self.__cookie = \
             self.__proxy.Inhibit("Caffeine", INHIBITION_REASON)
 
@@ -121,6 +127,9 @@ class XdgPowerManagmentInhibitor(BaseInhibitor):
         self.__proxy = \
             self.bus.get_object('org.freedesktop.PowerManagement.Inhibit',
                                 '/org/freedesktop/PowerManagement/Inhibit')
+        self.__proxy = \
+            dbus.Interface(self.__proxy,
+                           dbus_interface='org.freedesktop.PowerManagement.Inhibit')
         self.__cookie = \
             self.__proxy.Inhibit("Caffeine", INHIBITION_REASON)
         self.running = True


### PR DESCRIPTION
I run Arch Linux and GNOME 3 and installed this from the AUR. I was getting errors

```
dbus.exceptions.DBusException: org.freedesktop.DBus.Error.UnknownMethod: No such interface '(null)' on object at path /org/gnome/SessionManager
```

in the `GnomeInhibitor`. It appears that we are required to specify the `dbus_interface` when making proxy calls, so I wrapped the proxies in `Interface`s as per [the tutorial](https://dbus.freedesktop.org/doc/dbus-python/doc/tutorial.html#interfaces-and-methods).

This fixed the stacktrace but the inhibitor was not showing up in `systemd-inhibit --list`. 

Investigating another caffeine [indicates that an additional flag is required](https://github.com/eonpatapon/gnome-shell-extension-caffeine/issues/16#issuecomment-45472880) which is [documented at GNOME](https://people.gnome.org/~mccann/gnome-session/docs/gnome-session.html#org.gnome.SessionManager.Inhibit).

After adding the extra flag in the `Inhibit()` call to `org.gnome.SessionManager` caffeine-ng now works as expected for me.
